### PR TITLE
Expose a web3.confidential.contract interface

### DIFF
--- a/web3c/ceth.js
+++ b/web3c/ceth.js
@@ -2,36 +2,34 @@
 // sendTransaction to add encryption.
 const KeyManager = require('./keymanager');
 
-let Ceth = function (eth) {
-  let self = this;
-
-  self.keyManager = new KeyManager();
+function Ceth (eth) {
+  this.keyManager = new KeyManager();
 
   // calls to Ceth.contract() should route calls back through the shim.
-  let boundContract = eth.contract.bind(self);
-  self.contract = function (abi) {
+  let boundContract = eth.contract.bind(this);
+  this.contract = function (abi) {
     let inst = boundContract(abi);
     let boundAt = inst.at.bind(inst);
     // TODO: handle confidential creation via an update .new() method.
-    inst.at = function (address, callback, key) {
-      self.keyManager.add(address, key);
+    inst.at = (address, callback, key) => {
+      this.keyManager.add(address, key);
       return boundAt(address, callback);
-    };
+    }
     return inst;
   }
 
-  self._requestManager = eth._requestManager;
-  self._eth = eth;
+  this._requestManager = eth._requestManager;
+  this._eth = eth;
 
   // Note: will need to change for hidden contract code.
-  self.getCode = eth.getCode.bind(eth);
+  this.getCode = eth.getCode.bind(eth);
   // Note: does receipt need to be decrypted?
-  self.getTransactionReceipt = eth.getTransactionReceipt.bind(eth);
-  self.estimateGas = eth.estimateGas.bind(eth);
-  self.filter = eth.estimateGas.bind(eth);
+  this.getTransactionReceipt = eth.getTransactionReceipt.bind(eth);
+  this.estimateGas = eth.estimateGas.bind(eth);
+  this.filter = eth.estimateGas.bind(eth);
 
-  return self;
-};
+  return this;
+}
 
 Ceth.prototype.sendTransaction = function (options, callback) {
   // TODO: encrypt data

--- a/web3c/confidential.js
+++ b/web3c/confidential.js
@@ -6,7 +6,7 @@ const Confidential = function (web3) {
 
   let self = this;
 
-  self.methods(web3._extend).forEach(function (method) {
+  Confidential.methods(web3._extend).forEach(function (method) {
     method.attachToObject(self);
   });
 

--- a/web3c/index.js
+++ b/web3c/index.js
@@ -4,10 +4,7 @@ const Confidential = require('./confidential');
 function makeWeb3c (web3) {
   return function (provider) {
     let obj = new web3(provider);
-    obj._extend({
-      property: 'confidential',
-      methods: Confidential.methods(obj._extend)
-    });
+    obj.confidential = new Confidential(obj);
     return obj;
   }
 }

--- a/web3c/keymanager.js
+++ b/web3c/keymanager.js
@@ -1,35 +1,37 @@
 // Stores known short and longterm keys for contracts,
 // refreshing + validating short-term keys as needed.
 
-let KeyManager = function (confidential) {
-  this._DB = {};
+function KeyManager (confidential) {
+  this._db = new Map();
   this._remote = confidential;
-};
+}
 
 KeyManager.prototype.add = function (address, key) {
-  this._DB[address] = {
+  this._db[address] = {
     longterm: key
   };
 };
 
 KeyManager.prototype.get = function (address, callback) {
-  if (!this._DB[address]) {
+  if (!this._db[address]) {
     return callback(new Error('no known contract at requested address'));
   }
   // TODO: check timestamp expiry.
-  if (this._DB[address].shorterm) {
-    return callback(this._DB[address].shorterm);
+  if (this._db[address].shorterm) {
+    return callback(this._db[address].shorterm);
   }
   this._remote.getPublicKey(address, this.onKey.bind(this, address, callback));
 };
 
 KeyManager.prototype.onKey = function (address, cb, response) {
-  if (!this._DB[address]) {
+  if (!this._db[address]) {
     throw new Error('Recieved key for unregistered address');
   }
   // TODO: check if response is an error.
   // TODO: validate response signature is from lngterm key.
-  this._DB[address].shortterm = response.key;
-  this._DB[address].timestamp = response.timestamp;
+  this._db[address].shortterm = response.key;
+  this._db[address].timestamp = response.timestamp;
   cb(response.key);
 };
+
+module.exports = KeyManager;


### PR DESCRIPTION
a hooked version of a standard `web3.eth.contract`, where the underlying `.eth` object the contract uses is actually a hooked version, here called `.ceth`, that can perform encryption and decryption of the underlying calls made.
Also adds scaffold for a key manager to refresh and handle key management on the client side.

Address #5 