### PR TITLE
Gateway returns public key option

### DIFF
--- a/test/keymanager.js
+++ b/test/keymanager.js
@@ -63,18 +63,18 @@ describe('Key Manager', function() {
 
     // Load shorterm key from web3
     let ret = null;
-    km.get('that', (key) => {ret = key;});
+    km.get('that', (err, key) => {ret = key;});
     assert.equal(ret, 'stkey');
 
     // reloading should work
     ret = null;
-    km.get('that', (key) => {ret = key;});
+    km.get('that', (err, key) => {ret = key;});
     assert.equal(ret, 'stkey');
 
     // trying to get local key should fail.
     ret = null;
     assert.throws(() => {
-      km.get('me', (key) => {ret = key;});
+      km.get('me', (err, key) => {ret = key;});
     })
     assert.equal(ret, null);
 

--- a/test/mockgateway/index.js
+++ b/test/mockgateway/index.js
@@ -92,8 +92,8 @@ async function handleRequest (req) {
       } else {
         obj.result = responses.CONFIDENTIAL_DEPLOY_TX_HASH;
       }
-	} else if (req.params[0].to === responses.OASIS_DEPLOY_PLAINTEXT_TX_RECEIPT.contractAddress) {
-	  obj.result = responses.OASIS_PLAINTEXT_TX_HASH;
+    } else if (req.params[0].to === responses.OASIS_DEPLOY_PLAINTEXT_TX_RECEIPT.contractAddress) {
+      obj.result = responses.OASIS_PLAINTEXT_TX_HASH;
     } else {
       // Transact
       try {
@@ -124,8 +124,8 @@ async function handleRequest (req) {
     } else if (req.params[0] === responses.OASIS_DEPLOY_HEADER_PLAINTEXT_TX_HASH) {
       obj.result = responses.OASIS_DEPLOY_PLAINTEXT_TX_RECEIPT;
     } else if (req.params[0] === responses.OASIS_PLAINTEXT_TX_HASH) {
-	  obj.result = responses.OASIS_PLAINTEXT_TX_RECEIPT;
-	}
+      obj.result = responses.OASIS_PLAINTEXT_TX_RECEIPT;
+    }
   } else if (req.method == 'eth_getCode') {
     obj.result = artifact.bytecode;
   } else if (req.method == 'eth_getLogs') {

--- a/test/web3c.js
+++ b/test/web3c.js
@@ -229,19 +229,19 @@ describe('Web3', () => {
       }
     }).send({ gas: '0x10000' });
 
-	assert.equal(
-	  plaintextInstance.options.address.toLowerCase(),
-	  gateway.responses.OASIS_DEPLOY_PLAINTEXT_TX_RECEIPT.contractAddress
-	);
+    assert.equal(
+      plaintextInstance.options.address.toLowerCase(),
+      gateway.responses.OASIS_DEPLOY_PLAINTEXT_TX_RECEIPT.contractAddress
+    );
   }).timeout(timeout);
 
   it('should send a transaction to a non confidential contract in the oasis namespace', async () => {
     const receipt = await plaintextInstance.methods.incrementCounter().send({
       from: address,
       gasPrice: '0x3b9aca00',
-	  gas: '0x10000'
+      gas: '0x10000'
     });
-	assert.equal(receipt.transactionHash, gateway.responses.OASIS_PLAINTEXT_TX_HASH);
+    assert.equal(receipt.transactionHash, gateway.responses.OASIS_PLAINTEXT_TX_HASH);
 
   }).timeout(timeout);
 

--- a/web3c/provider_confidential_backend.js
+++ b/web3c/provider_confidential_backend.js
@@ -219,7 +219,10 @@ class ConfidentialSendTransform {
    * @param callback Function
    */
   encryptTx(tx, callback) {
-    return this.keymanager.get(tx.to, (key) => {
+    return this.keymanager.get(tx.to, (err, key) => {
+      if (err) {
+        callback(err);
+      }
       if (typeof key !== 'string') { // error
         return callback(key);
       }


### PR DESCRIPTION
The key manager api in ekiden and the runtime has changed so that, instead of erroring when a public key doesn't exist (say, for a non-confidential contract), it returns an option back.

This is the corresponding client change.