### PR TITLE
Bump version to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web3c",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Confidentiality extension for Web3",
   "main": "index.node.js",
   "module": "index.browser.js",


### PR DESCRIPTION
Bumping the version so that we can use the new ability to inject `options` in `oasis-debug`.