### PR TITLE
Only require node-localstorage if storage is needed

### DIFF
--- a/index.node.js
+++ b/index.node.js
@@ -1,6 +1,5 @@
 // Web3c
 const web3 = require('web3');
-const localStorage = require('node-localstorage');
 const Oasis = require('./web3c/oasis');
 /**
  * Web3c is a wrapper that can be invoked in the same way as Web3.
@@ -28,6 +27,7 @@ function buildOptions(web3, options) {
   options.web3 = web3;
 
   if (!options.storage) {
+    const localStorage = require('node-localstorage');
     options.storage = new localStorage.LocalStorage('.web3c');
   }
   if (!options.mraebox) {


### PR DESCRIPTION
This is a quick fix for getting react native to work. 

For now, we will require storage to be injected.

In the future, we should provide a native option for storage.