### PR TITLE
cleanup unused subscriptions

### DIFF
--- a/test/web3c.js
+++ b/test/web3c.js
@@ -426,7 +426,6 @@ describe('Web3', () => {
       assert.fail(new Error('error timeout should have been raised'));
     } catch(e) {
       assert.equal(e.message, 'subscription timed out');
-      console.log('subscriptions: ', web3c.oasis._invokeSubscription.subscriptions);
       assert.equal(utils.isEmptyObject(web3c.oasis._invokeSubscription.subscriptions), true);
     }
   });

--- a/web3c/invoke_subscriptions.js
+++ b/web3c/invoke_subscriptions.js
@@ -176,7 +176,6 @@ class InvokeSubscriptions {
   }
 
   cleanupSubscription(fromAddress, err) {
-    console.log('cleanup subscription: ', fromAddress);
     const subscription = this.subscriptions[fromAddress];
     if (!subscription) {
       return;

--- a/web3c/oasis.js
+++ b/web3c/oasis.js
@@ -374,10 +374,10 @@ class Oasis {
         .then(receipt => resolvableEmitter.emit('receipt', receipt))
         .catch(err => {
           error = err;
-          promise.resolver.reject(err);
           if (transactionHash) {
             this._invokeSubscription.removeExpectedTransaction(fromAddress, transactionHash);
           }
+          promise.resolver.reject(err);
         });
 
       return resolvableEmitter;

--- a/web3c/oasis.js
+++ b/web3c/oasis.js
@@ -350,11 +350,19 @@ class Oasis {
       const resolvableEmitter = utils.resolvableEmitterFromPromise(promise.then(result =>
         contract._decodeMethodReturn(outputs, result)));
       let transactionHash;
+      let error;
 
       sendEmitter
         .on('error', err => resolvableEmitter.emit('error', err))
         .on('transactionHash', hash => {
           transactionHash = hash;
+
+          if (error) {
+            // if an error has already been handled
+            // then ignore
+            return;
+          }
+
           this._invokeSubscription.pushExpectedTransaction(fromAddress, {
             transactionHash: hash,
             toAddress: address,
@@ -365,6 +373,7 @@ class Oasis {
         })
         .then(receipt => resolvableEmitter.emit('receipt', receipt))
         .catch(err => {
+          error = err;
           promise.resolver.reject(err);
           if (transactionHash) {
             this._invokeSubscription.removeExpectedTransaction(fromAddress, transactionHash);

--- a/web3c/utils.js
+++ b/web3c/utils.js
@@ -44,9 +44,43 @@ function resolvableEmitterFromPromise(promise) {
   return promise;
 }
 
+/**
+ * returns true if the result is an empty object
+ * false otherwise. It will throw an error if the
+ * argument is not an object, null or undefined
+ */
+function isEmptyObject(o) {
+  if (o === null || o === undefined) {
+    return true;
+  }
+
+  if (typeof o !== 'object') {
+    throw new Error('provided argument must be an object');
+  }
+
+  for (const key in o) {
+    if (o.hasOwnProperty(key)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * returns false if the result is an empty object
+ * true otherwise. It will throw an error if the
+ * argument is not an object, null or undefined
+ */
+function isNotEmptyObject(o) {
+  return !isEmptyObject(o);
+}
+
 module.exports = {
   objectAssign,
   createResolvablePromise,
   createResolvableEmitter,
   resolvableEmitterFromPromise,
+  isEmptyObject,
+  isNotEmptyObject
 };


### PR DESCRIPTION
cleanup unused subscriptions with a default timeout of 1m.

I'm not sure about this approach, but I wanted to know @willscott @armaniferrante what you think of this.

My main concern is the amount of `setTimeout` that will be calling. If this has to handle a high volume of transactions we should do it differently. As far as I can tell, internally in Web3, they use a similar approach though.
